### PR TITLE
Add stubs for Lego Spike API

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spike_stubs"]
+	path = spike_stubs
+	url = https://github.com/jvolkening/lego-spike-python-v3-docs.git

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "python.analysis.extraPaths": [
-        "C:\\Users\\Chris\\python\\lego-spike-python-v3-docs\\stubs"
-    ]
+        "C:\\Users\\Chris\\python\\lego-spike-python-v3-docs\\stubs",
+        ".\\spike_stubs\\stubs"
+    ],
+    "python.analysis.typeCheckingMode": "basic"
 }

--- a/master.py
+++ b/master.py
@@ -3,7 +3,7 @@
 from hub import button
 import asyncio
 
-mission_list = ['02', '19']
+mission_list = ['02', '19', '15']
 mission_imports = {}
 
 def importslot(slot_number: str):

--- a/mission0.py
+++ b/mission0.py
@@ -30,7 +30,7 @@ async def maina():
    await light_matrix.write("Hi!")
    runloop.run(sleepfor(),runto(),listenforbroadcast())
    print('done with asyncs')
-   runto()
+   future = runto()
 
 
 async def listenforbroadcast():


### PR DESCRIPTION
Added submodule for Documentation of the Spike Prime API which includes a stub folder to add in to settings.json

"python.analysis.extraPaths": [
        "C:\\Users\\Chris\\python\\lego-spike-python-v3-docs\\stubs",
        ".\\spike_stubs\\stubs"

    ],